### PR TITLE
Added support for Laravel 9 and 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "illuminate/contracts": "^5.5|^6|^7|^8",
-        "illuminate/support": "^5.5|^6|^7|^8",
+        "illuminate/contracts": "^5.5|^6|^7|^8|^9|^10",
+        "illuminate/support": "^5.5|^6|^7|^8|^9|^10",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": { },


### PR DESCRIPTION
Added ^9|^10" to the accepted versions of illuminate contracts & support.
